### PR TITLE
I think 'call pathogen#helptags' shouldn't be in the README since it's in the vimrc file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,15 +48,6 @@ To update all submodules, use the following command on vimfiles dir:
 
     git submodule foreach git pull origin master
 
-Help Tags
----------
-
-At first usage of vim, type ":" while in command mode and execute:
-
-    call pathogen#helptags()
-
-This will make the plugins documentations available upon `:help`
-
 Dependencies
 ------------
 


### PR DESCRIPTION
The user doesn't have to do 'call pathogen#helptags' because it's in vimrc since e1d9deae2898a1c965a743f8ee02c5439cb0915d
